### PR TITLE
Using PEP 3101 compliant string formatting

### DIFF
--- a/Lessons/PythonIntro.ipynb
+++ b/Lessons/PythonIntro.ipynb
@@ -597,8 +597,8 @@
    },
    "outputs": [],
    "source": [
-    "print \"%.20f\" % (0.1 + 0.2) # don't worry about the print statements now; they tell us how many decimals to print \n",
-    "print \"%0.20f\" % (0.3) # clearly these two are not equal! careful with floats."
+    "print \"{0:.20f}\".format(0.1 + 0.2) # don't worry about the print statements now; they tell us how many decimals to print \n",
+    "print \"{0:.20f}\".format(0.3) # clearly these two are not equal! careful with floats."
    ]
   },
   {
@@ -949,10 +949,10 @@
    "outputs": [],
    "source": [
     "# let's try to see in detail how this slicing works, step-by-step:\n",
-    "print \"first bin slice: %s\" % str(bins[1:])\n",
-    "print \"second bin slice: %s\" % str(bins[:-1])\n",
-    "print \"bin slices added: %s\" % (str(bins[1:] + bins[:-1]))\n",
-    "print \"bin centers: %s\" % str(bincenters)"
+    "print \"first bin slice: {0}\".format(str(bins[1:]))\n",
+    "print \"second bin slice: {0}\".format(str(bins[:-1]))\n",
+    "print \"bin slices added: {0}\".format(str(bins[1:] + bins[:-1]))\n",
+    "print \"bin centers: {0}\".format(str(bincenters))"
    ]
   },
   {


### PR DESCRIPTION
I made one small tweak to make their minds better primed for using modern Python features (like those in Python 3).

Since "new" string formatting introduced in [PEP 3101](https://www.python.org/dev/peps/pep-3101/) is the most modern way of doing string formatting, I swapped out the old C-style string formatting examples for their newer equivalents.
